### PR TITLE
Add page wait to index.js for file's with content

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,9 @@ async function generatePdf(file, options, callback) {
     const html = result;
 
     // We set the page content as the generated html by handlebars
-    await page.setContent(html);
+    await page.setContent(html, {
+      waitUntil: 'networkidle0', // wait for page to load completely
+    });
   } else {
     await page.goto(file.url, {
       waitUntil: 'networkidle0', // wait for page to load completely


### PR DESCRIPTION
Added page wait to load the page for file's with content as well as URLs, so css imports load before PFD is generated.

See this issue https://github.com/puppeteer/puppeteer/issues/422

