### PR TITLE
Upgrade puppeteer dependency to fix browser revision error

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "bluebird": "^3.7.2",
     "handlebars": "^4.7.6",
-    "puppeteer": "^5.1.0"
+    "puppeteer": "^10.2.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
I was getting this in a Docker container using your package:

`Could not find browser revision 818858. Run "PUPPETEER_PRODUCT=firefox npm install" or "PUPPETEER_PRODUCT=firefox yarn install" to download a supported Firefox browser binary.`

I forked your repo, bumped the puppeteer version, e voila.