### PR TITLE
bumping puppeteer to ^10.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "bluebird": "^3.7.2",
     "handlebars": "^4.7.6",
-    "puppeteer": "^5.1.0"
+    "puppeteer": "^10.4.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
This just bumps puppeteer from ^5.1.0 to ^10.4.0.  
I inspected the new interface, and no outer functions seem to have changed, at least not the ones used by html-pdf-node. 
Also, all tests pass with the bumped puppeteer. 