### PR TITLE
feat: accepts headers for puppeteer goto request

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,10 @@ async function generatePdf(file, options, callback) {
       waitUntil: 'networkidle0', // wait for page to load completely
     });
   } else {
+    //Accepts an object with a list of headers if present
+    if(file.headers){
+      await page.setExtraHTTPHeaders(file.headers);
+    }
     await page.goto(file.url, {
       waitUntil:[ 'load', 'networkidle0'], // wait for page to load completely
     });
@@ -73,6 +77,10 @@ async function generatePdfs(files, options, callback) {
         waitUntil: 'networkidle0', // wait for page to load completely
       });
     } else {
+      //Accepts an object with a list of headers if present
+      if(file.headers){
+        await page.setExtraHTTPHeaders(file.headers);
+      }
       await page.goto(file.url, {
         waitUntil: 'networkidle0', // wait for page to load completely
       });


### PR DESCRIPTION
Accepts an object with a list of headers if present.

For example:

`
const headersObj = {
"accept": "application/json",
"accept-encoding": "gzip, deflate, br",
"accept-language": "en-US,en;q=0.9,en;q=0.8"
};

let file = { url: "http://localhost:3000", headers: headersObj };
html_to_pdf.generatePdf(file, options).then(pdfBuffer => {
  console.log("PDF Buffer:-", pdfBuffer);
});
`


